### PR TITLE
make explore button functional

### DIFF
--- a/src/components/pages/Home.jsx
+++ b/src/components/pages/Home.jsx
@@ -1,7 +1,11 @@
+import { useContext } from "react";
+import NavContext from "../../contexts/NavContext.jsx";
 import Navbar from "../Navbar.jsx";
 import css from "../../styles/_home.module.scss";
 
 export default function Home() {
+    const {setCurrentPage} = useContext(NavContext);
+
     return (
         <>
             <Navbar />
@@ -17,7 +21,7 @@ export default function Home() {
                     </p>
                 </div>
                 <div className={`${css["home__explore-btn-border"]} flex flex-jc-c`}>
-                    <button className={`${css["home__explore-btn"]} flex flex-jc-c flex-ai-c`}>Explore</button>
+                    <button className={`${css["home__explore-btn"]} flex flex-jc-c flex-ai-c`} onClick={() => setCurrentPage("01")}>Explore</button>
                 </div>
             </main>
         </>


### PR DESCRIPTION
Made it so when you click the explore button on the home page, it sets the current page state to "01". This will display the destination's page component.