### PR TITLE
resize explore button on mobile

### DIFF
--- a/src/styles/_home.module.scss
+++ b/src/styles/_home.module.scss
@@ -106,6 +106,7 @@ body {
     &__explore-btn {
       width: 10rem;
       height: 10rem;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
Set the padding of the explore button to 0 when in mobile view. This sets the button's size to an appropriate size.