### PR TITLE
Fix tablet nav

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,11 +1,11 @@
 @mixin mobile {
-  @media only screen and (max-width: 62.4375rem) {
+  @media only screen and (max-width: 47.9375rem) {
     @content;
   }
 }
 
 @mixin tablet {
-  @media only screen and (min-width: 62.5rem) and (max-width: 79.9375rem) {
+  @media only screen and (min-width: 48rem) and (max-width: 79.9375rem) {
     @content;
   }
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin mobile {
-  @media only screen and (max-width: 47.9375rem) {
+  @media only screen and (max-width: 47.9688rem) {
     @content;
   }
 }

--- a/src/styles/_navbar.module.scss
+++ b/src/styles/_navbar.module.scss
@@ -139,12 +139,22 @@
 
 @include tablet {
   .navbar {
-    &__line {
-      display: none;
+    &--desktop {
+      &__line {
+        display: none;
+      }
+
+      &__links {
+        margin-top: 0;
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 70%;
+      }
     }
 
-    &__list {
-      width: 100%;
+    &__logo {
+      margin-top: 1%;
     }
   }
 }


### PR DESCRIPTION
MIXINS:

- Changed tablet mixin to (min-width: 48rem) and (max-width: 79.9375rem)
- Changed mobile mixin to (max-width: 47.9688rem)

NAVBAR:

- Made the navbar position absolute and it's top 0.
- Made its width be 70%.
- Gave 1% margin-top to the logo to compensate for the navbar's absolute positioning.